### PR TITLE
change pylibmc MemcachedError exception import

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -20,7 +20,7 @@ from django.core.cache.backends.memcached import BaseMemcachedCache
 
 try:
     import pylibmc
-    MemcachedError = pylibmc._pylibmc.MemcachedError
+    from pylibmc import Error as MemcachedError
 except ImportError:
     raise InvalidCacheBackendError('Could not import pylibmc.')
 


### PR DESCRIPTION
Wouldn't it be more Pythonic and lessen the risk of breakage due to future changes in pylibmc to do the import without referencing the protected namespace.

http://sendapatch.se/projects/pylibmc/misc.html#exceptions

```
python tests/tests.py
Creating test database for alias 'default'...
.....................................................................
----------------------------------------------------------------------
Ran 69 tests in 22.331s

OK
Destroying test database for alias 'default'...
```
