### PR TITLE
Use params-provided username and password if available

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -41,8 +41,8 @@ class PyLibMCCache(BaseMemcachedCache):
         import os
         self._local = local()
         self.binary = int(params.get('BINARY', False))
-        self._username = os.environ.get('MEMCACHE_USERNAME', username)
-        self._password = os.environ.get('MEMCACHE_PASSWORD', password)
+        self._username = os.environ.get('MEMCACHE_USERNAME', username or params.get('USERNAME'))
+        self._password = os.environ.get('MEMCACHE_PASSWORD', password or params.get('PASSWORD'))
         self._server = os.environ.get('MEMCACHE_SERVERS', server)
         super(PyLibMCCache, self).__init__(self._server, params, library=pylibmc,
                                            value_not_found_exception=pylibmc.NotFound)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,6 +16,8 @@ CACHES = {
         'LOCATION': 'localhost:11211',
         'TIMEOUT': 500,
         'BINARY': True,
+        'USERNAME': 'test_username',
+        'PASSWORD': 'test_password',
         'OPTIONS': {
             'tcp_nodelay': True,
             'ketama': True


### PR DESCRIPTION
Prefer os.environ or explicitly-constructed values over params
for backwards-compatibility.

This allows auth to be provided through django's CACHES setting in addition to the existing environment-variable approach.
