### PR TITLE
Use cPickle+zlib (when applicable) to report the bytes sent in error messages

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -126,7 +126,7 @@ class PyLibMCCache(BaseMemcachedCache):
     def _serialize_value(self, value):
         if MIN_COMPRESS_LEN > 0:
             import zlib
-            return zlib.compress(cPickle.dumps(value))
+            return zlib.compress(cPickle.dumps(value), COMPRESS_LEVEL)
         else:
             return cPickle.dumps(value)
 


### PR DESCRIPTION
So we rolled my last patch out to production and realized a drastic mistake. Just calling str() will give us an incorrect reporting of bytes. We had values that were near 1mb and were getting a report that they were a mere 3801 bytes because of **str** being called. ;-)

Unfortunately pylibmc has the code to serialize and compress embeded in a way that we cannot call them outside of pylibmc, so this code seeks to replicate it the best way possible to capture the accurate number of bytes sent. 
