### PR TITLE
Use Pickle+zlib When Applicable

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -126,7 +126,7 @@ class PyLibMCCache(BaseMemcachedCache):
     def _serialize_value(self, value):
         if MIN_COMPRESS_LEN > 0:
             import zlib
-            return zlib.compress(cPickle.dumps(value))
+            return zlib.compress(cPickle.dumps(value), COMPRESS_LEVEL)
         else:
             return cPickle.dumps(value)
 


### PR DESCRIPTION
The log message was off a bit when just passing the value to str(). This approach uses the actual way it is done under the hood. 
