### PR TITLE
Upgrade to pylibmc-1.4.1, Django 1.5-1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .tox
+*.pyc
+django_pylibmc.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tox
 *.pyc
 django_pylibmc.egg-info
+pylibmc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Config file for automatic testing at travis-ci.org
+
+language: python
+install: pip install tox
+script: tox
+
+env:
+  - TOXENV=py26-django15
+  - TOXENV=py27-django15
+  - TOXENV=py33-django15
+  - TOXENV=py26-django16
+  - TOXENV=py27-django16
+  - TOXENV=py33-django16
+  - TOXENV=py27-django17
+  - TOXENV=py33-django17
+  - TOXENV=py34-django17
+
+# See pylibmc's .travis.yml if a lot more configuration is needed
+services:
+  - memcached

--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,10 @@ This package provides a memcached cache backend for Django using
 `pylibmc <http://github.com/lericson/pylibmc>`_.  You want to use pylibmc because
 it's fast.
 
-
 Requirements
 ------------
 
-django-pylibmc requires Django 1.3+.  It was written and tested on Python 2.7.
+django-pylibmc requires Django 1.5+.  It was written and tested on Python 2.7.
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 pylibmc cache backend for Django
 ================================
 
-`This project needs a maintainer. <https://github.com/django-pylibmc/django-pylibmc/issues/31>`_
+.. image:: https://travis-ci.org/jbalogh/django-pylibmc.svg
+    :target: https://travis-ci.org/jbalogh/django-pylibmc
 
 This package provides a memcached cache backend for Django using
 `pylibmc <http://github.com/lericson/pylibmc>`_.  You want to use pylibmc because

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -110,14 +110,14 @@ class PyLibMCCache(BaseMemcachedCache):
             log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),
                       exc_info=True)
             return False
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False
 
     def get(self, key, default=None, version=None):
         try:
             return super(PyLibMCCache, self).get(key, default, version)
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return default
 
@@ -131,34 +131,34 @@ class PyLibMCCache(BaseMemcachedCache):
             log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),
                       exc_info=True)
             return False
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False
 
     def delete(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).delete(*args, **kwargs)
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False
 
     def get_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).get_many(*args, **kwargs)
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return {}
 
     def set_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).set_many(*args, **kwargs)
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False
 
     def delete_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).delete_many(*args, **kwargs)
-        except MemcachedError, e:
+        except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=['django_pylibmc'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['pylibmc>=1.4.1', 'Django>=1.5,<1.7'],
+    install_requires=['pylibmc>=1.4.1', 'Django>=1.5,<1.8'],
     tests_require=['tox'],
     cmdclass = {'test': Tox},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=['django_pylibmc'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['pylibmc>=1.1', 'Django>=1.2'],
+    install_requires=['pylibmc>=1.4.1', 'Django>=1.5,<1.7'],
     tests_require=['tox'],
     cmdclass = {'test': Tox},
     classifiers=[

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,16 +13,22 @@ INSTALLED_APPS = (
 CACHES = {
     'default': {
         'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
-        'LOCATION': 'localhost:11211',
-        'TIMEOUT': 500,
+        'LOCATION': '127.0.0.1:11211',
+    },
+    'binary': {
+        'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
+        'LOCATION': '127.0.0.1:11211',
         'BINARY': True,
-        'USERNAME': 'test_username',
-        'PASSWORD': 'test_password',
+    },
+    'with_options': {
+        'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
+        'LOCATION': '127.0.0.1:11211',
         'OPTIONS': {
             'tcp_nodelay': True,
             'ketama': True
         }
-    }
+    },
+
 }
 
 PYLIBMC_MIN_COMPRESS_LEN = 150 * 1024

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,3 +29,12 @@ PYLIBMC_MIN_COMPRESS_LEN = 150 * 1024
 PYLIBMC_COMPRESS_LEVEL = 1  # zlib.Z_BEST_SPEED
 
 SECRET_KEY = 'secret'
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -178,7 +178,7 @@ class BaseCacheTests(object):
     def test_binary_string(self):
         # Binary strings should be cachable
         from zlib import compress, decompress
-        value = 'value_to_be_compressed'
+        value = b'value_to_be_compressed'
         compressed_value = compress(value)
         self.cache.set('binary1', compressed_value)
         compressed_result = self.cache.get('binary1')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,6 +14,13 @@ from django.core.cache import get_cache
 
 from app.models import Poll, expensive_calculation
 
+try:
+    from django import setup
+except ImportError:
+    # Django 1.6 and below does not require setup
+    setup = lambda: None
+else:
+    assert setup
 
 # functions/classes for complex data type tests
 def f():
@@ -263,6 +270,7 @@ class PylibmcCacheWithOptionsTests(unittest.TestCase, BaseCacheTests):
 
 
 if __name__ == '__main__':
+    setup()
     runner = simple.DjangoTestSuiteRunner()
     try:
         old_config = runner.setup_databases()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py34
 
 [testenv]
 commands = {envpython} tests/tests.py
+deps =
+    pylibmc>=1.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py34
+envlist =
+    py{26,27,33}-django15,
+    py{26,27,33}-django16,
+    py{27,33,34}-django17
 
 [testenv]
 commands = {envpython} tests/tests.py
 deps =
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
     pylibmc>=1.4.1


### PR DESCRIPTION
This pull request combines a number of changes:

- Update to pylibmc 1.4.1, which includes Python 3 support
- Django 1.5+ is required
- Updates for Python 3.3 and Python 3.4, including @ghinch's changes in PR #16 
- Updates tox to test combinations of Python 2.6, 2.7, 3.3, and 3.4 against Django 1.5, 1.6, and 1.7
- Adds Travis CI configuration, and adjusts tests to work in that environment.

This drops support for Django 1.2, 1.3, and 1.4.  You'll have to signup for Travis CI and enable Github integration to get the badge working, which takes 5-10 minutes.

I've been running with these changes in mozilla/web-platform-compat, and I'd like to see an official PyPI release to match pylibmc 1.4.