### PR TITLE
Fix ._get_memcache_timeout() call DeprecationWarning for Django 1.8

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -97,13 +97,22 @@ class PyLibMCCache(BaseMemcachedCache):
         return client
 
     def _get_memcache_timeout(self, timeout=DEFAULT_TIMEOUT):
+        # ._get_memcache_timeout() will be deprecated in Django 1.9
+        # It's already raising DeprecationWarnint in Django 1.8
+        # See: https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9
+        try:
+            return self.get_backend_timeout(timeout)
+        except AttributeError:
+            return super(PyLibMCCache, self)._get_memcache_timeout(timeout)
+
+    def get_backend_timeout(self, timeout=DEFAULT_TIMEOUT):
         """
         Special case timeout=0 to allow for infinite timeouts.
         """
         if timeout == 0:
             return timeout
-        else:
-            return super(PyLibMCCache, self)._get_memcache_timeout(timeout)
+
+        return super(PyLibMCCache, self).get_backend_timeout(timeout)
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -96,15 +96,6 @@ class PyLibMCCache(BaseMemcachedCache):
 
         return client
 
-    def _get_memcache_timeout(self, timeout=DEFAULT_TIMEOUT):
-        # ._get_memcache_timeout() will be deprecated in Django 1.9
-        # It's already raising DeprecationWarnint in Django 1.8
-        # See: https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9
-        try:
-            return self.get_backend_timeout(timeout)
-        except AttributeError:
-            return super(PyLibMCCache, self)._get_memcache_timeout(timeout)
-
     def get_backend_timeout(self, timeout=DEFAULT_TIMEOUT):
         """
         Special case timeout=0 to allow for infinite timeouts.
@@ -112,13 +103,19 @@ class PyLibMCCache(BaseMemcachedCache):
         if timeout == 0:
             return timeout
 
-        return super(PyLibMCCache, self).get_backend_timeout(timeout)
+        try:
+            return super(PyLibMCCache, self).get_backend_timeout(timeout)
+        except AttributeError:
+            # ._get_memcache_timeout() will be deprecated in Django 1.9
+            # It's already raising DeprecationWarning in Django 1.8
+            # See: https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9
+            return self._get_memcache_timeout(timeout)
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)
         try:
             return self._cache.add(key, value,
-                                   self._get_memcache_timeout(timeout),
+                                   self.get_backend_timeout(timeout),
                                    **COMPRESS_KWARGS)
         except pylibmc.ServerError:
             log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),
@@ -139,7 +136,7 @@ class PyLibMCCache(BaseMemcachedCache):
         key = self.make_key(key, version=version)
         try:
             return self._cache.set(key, value,
-                                   self._get_memcache_timeout(timeout),
+                                   self.get_backend_timeout(timeout),
                                    **COMPRESS_KWARGS)
         except pylibmc.ServerError:
             log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),


### PR DESCRIPTION
`._get_memcache_timeout()` will be deprecated in Django 1.9 and it's already raising `DeprecationWarning` that recommends to use `.get_backend_timeout()` instead.