### PR TITLE
No longer override Django's native timeout parameter handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 
+sudo: required
+dist: trusty
 language: python
+python: "3.5"
 install: pip install tox
 script: tox
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+- **Backwards incompatible:** No longer override the native Django memcache
+  timeout behaviour. This means that using a timeout of ``0`` now results in
+  'immediately expire' rather than an infinite timeout. To maintain previous
+  behaviour use ``None`` instead, consistent with the `Django documentation
+  <https://docs.djangoproject.com/en/stable/topics/cache/#cache-arguments>`_.
+
 0.6.1 - 2015-12-28
 ------------------
 - Supports Django 1.7 through 1.9

--- a/README.rst
+++ b/README.rst
@@ -104,29 +104,19 @@ variables:
 
 Caching Timouts
 ---------------
+
 When setting a cache value, memcache allows you to set an expiration for the
-value. Commonly, the value is set to a timeout in seconds. However, other
-values are allowed including Unix timestamps and 0 for "never expire". The
-highest number of seconds is 30 days - more than that, and the value is
-treated like a timestamp.
+value. django-pylibmc no longer overrides the native Django pylibmc backend's
+timeout handling as the Django bug preventing setting infinite timeouts was
+fixed in Django 1.6.
 
-Django instead tries to work with cache timeouts in seconds after the current
-time. 0 is treated as 0 seconds, meaning the item should expire immediately.
-A timeout of None signals that the item should not expire. There is some
-support for memcache-style Unix timestamps as well.
+As such, you must now set the Django cache ``TIMEOUT`` option (or the ``timeout``
+parameter to individual caching calls) to ``None`` for an infinite timeout, or
+to ``0`` for 'immediately expire'.
 
-In the distant past (Django 1.3?), a timeout of 0 was converted to the default
-timeout.
+For more details, see the `Django cache timeout documentation
+<https://docs.djangoproject.com/en/stable/topics/cache/#cache-arguments>`_.
 
-The current django-pylibmc behaviour is to pass 0 to the backend, which should
-be interpreted as "never expire". Omiting the timeout will get the Django
-default.
-
-In the future, django-pylibmc will adopt the latest Django behaviour.
-The safest solution for your own code is to omit the timeout parameter (and
-get the default timeout), or set it to a timeout in seconds (less than 30
-days). This way, your code will work when the Django behaviour is adopted.
-Avoid using a timeout of 0, None, or a negative number.
 
 Testing
 -------

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -6,9 +6,6 @@ settings.  The default is `False`, using the text protocol.
 
 pylibmc behaviors can be declared as a dict in `CACHES` backend `OPTIONS`
 setting.
-
-Unlike the default Django caching backends, this backend lets you pass 0 as a
-timeout, which translates to an infinite timeout in memcached.
 """
 import logging
 import warnings
@@ -95,21 +92,6 @@ class PyLibMCCache(BaseMemcachedCache):
         self._local.client = client
 
         return client
-
-    def get_backend_timeout(self, timeout=DEFAULT_TIMEOUT):
-        """
-        Special case timeout=0 to allow for infinite timeouts.
-        """
-        if timeout == 0:
-            return timeout
-
-        try:
-            return super(PyLibMCCache, self).get_backend_timeout(timeout)
-        except AttributeError:
-            # ._get_memcache_timeout() will be deprecated in Django 1.9
-            # It's already raising DeprecationWarning in Django 1.8
-            # See: https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9
-            return self._get_memcache_timeout(timeout)
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         key = self.make_key(key, version=version)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -27,7 +27,7 @@ def load_cache(name):
 
 
 # Lifted originally from django/regressiontests/cache/tests.py.
-# In Django 1.8 (and earlier), tests are in tests/cache/tests.py.
+# In Django 1.8 (and later), tests are in tests/cache/tests.py.
 class PylibmcCacheTests(TestCase):
     cache_name = 'default'
 
@@ -242,10 +242,8 @@ class PylibmcCacheTests(TestCase):
 
     def test_none_timeout(self):
         '''
-        Passing in None for the timeout results in the default timeout
-
-        In Django, it results in a value that is cached forever.  There's no
-        way to tell the difference in the context of a unit test.
+        Passing in None into timeout results in a value that is cached forever.
+        There's no way to tell the difference in the context of a unit test.
         '''
         self.cache.set('key1', 'eggs', None)
         self.assertEqual(self.cache.get('key1'), 'eggs')
@@ -262,23 +260,17 @@ class PylibmcCacheTests(TestCase):
 
     def test_zero_timeout(self):
         '''
-        Passing in zero for the timeout results in a value that is cached
-        forever.
-
-        In Django, it results in a value that is not cached.
+        Passing in zero into timeout results in a value that is not cached
         '''
         self.cache.set('key1', 'eggs', 0)
-        self.assertEqual(self.cache.get('key1'), 'eggs')
+        self.assertIsNone(self.cache.get('key1'))
 
         self.cache.add('key2', 'ham', 0)
-        self.assertEqual(self.cache.get('key2'), 'ham')
-        added = self.cache.add('key1', 'new eggs', None)
-        self.assertEqual(added, False)
-        self.assertEqual(self.cache.get('key1'), 'eggs')
+        self.assertIsNone(self.cache.get('key2'))
 
-        self.cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, None)
-        self.assertEqual(self.cache.get('key3'), 'sausage')
-        self.assertEqual(self.cache.get('key4'), 'lobster bisque')
+        self.cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, 0)
+        self.assertIsNone(self.cache.get('key3'))
+        self.assertIsNone(self.cache.get('key4'))
 
     def test_float_timeout(self):
         # Make sure a timeout given as a float doesn't crash anything.


### PR DESCRIPTION
Django has since fixed the issue that prevented setting an infinite timeout, which can now be done using a timeout value of `None`. However their chosen solution is not consistent with the approach taken by django-pylibmc's custom `get_backend_timeout()`.

Even though this is a non-backwards compatible change for people using a timeout value of `0` with django-pylibmc, the custom handling should still be removed, to:
- simplify the django-pylibmc codebase
- make django-pylibmc's behaviour consistent with the Django docs
- avoid changes in behaviour when people switch from the native backend
  to django-pylibmc, expecting it to be a drop-in replacement.

This change will need a major version bump of django-pylibmc.

Fixes #35.
