### PR TITLE
Ensure compress parameters are used in set_many

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+next
+----
+ - Ensure compress parameters are used in `set_many`.
+
 0.6.1 - 2015-12-28
 ------------------
 - Supports Django 1.7 through 1.9

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -160,9 +160,15 @@ class PyLibMCCache(BaseMemcachedCache):
             log.error('MemcachedError: %s' % e, exc_info=True)
             return {}
 
-    def set_many(self, *args, **kwargs):
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
+        safe_data = {}
+        for key, value in data.items():
+            key = self.make_key(key, version=version)
+            safe_data[key] = value
         try:
-            return super(PyLibMCCache, self).set_many(*args, **kwargs)
+            self._cache.set_multi(safe_data,
+                                  self.get_backend_timeout(timeout),
+                                  **COMPRESS_KWARGS)
         except MemcachedError as e:
             log.error('MemcachedError: %s' % e, exc_info=True)
             return False


### PR DESCRIPTION
The set_many method was not passing the compress parameters as the set method does. I have changed it accordingly.