### PR TITLE
Request Python versions from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,35 @@
 # Config file for automatic testing at travis-ci.org
 
+# sudo: false appears to work, and makes for fast builds.
+#  memcached is started with "sudo service memcached start", which issues a
+#  warning about sudo, but also appears to start the service.
+sudo: false
 language: python
 install: pip install tox
 script: tox
 
-env:
-  - TOXENV=py27-django18
-  - TOXENV=py34-django18
-  - TOXENV=py27-django19
-  - TOXENV=py34-django19
-  - TOXENV=py35-django19
-  - TOXENV=py27-django110
-  - TOXENV=py34-django110
-  - TOXENV=py35-django110
-  - TOXENV=py27-django-master
-  - TOXENV=py35-django-master
-
 matrix:
+    include:
+        - env: TOXENV=py27-django18
+          python: "2.7"
+        - env: TOXENV=py34-django18
+          python: "3.4"
+        - env: TOXENV=py27-django19
+          python: "2.7"
+        - env: TOXENV=py34-django19
+          python: "3.4"
+        - env: TOXENV=py35-django19
+          python: "3.5"
+        - env: TOXENV=py27-django110
+          python: "2.7"
+        - env: TOXENV=py34-django110
+          python: "3.5"
+        - env: TOXENV=py35-django110
+          python: "3.5"
+        - env: TOXENV=py27-django-master
+          python: "2.7"
+        - env: TOXENV=py35-django-master
+          python: "3.5"
     allow_failures:
         # Django master is allowed to fail
         - env: TOXENV=py27-django-master


### PR DESCRIPTION
When the Python version is unspecified, Python 2.7 is used. This explicitly requests Python 3.4 and 3.5, for more accurate tests.