### PR TITLE
Remove unneeded backwards compatibility support

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -16,18 +16,13 @@ from threading import local
 
 from django.conf import settings
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.core.cache.backends.memcached import BaseMemcachedCache
+from django.core.cache.backends.memcached import BaseMemcachedCache, DEFAULT_TIMEOUT
 
 try:
     import pylibmc
     from pylibmc import Error as MemcachedError
 except ImportError:
     raise InvalidCacheBackendError('Could not import pylibmc.')
-
-try:
-    from django.core.cache.backends.memcached import DEFAULT_TIMEOUT
-except ImportError:
-    DEFAULT_TIMEOUT = None
 
 
 log = logging.getLogger('django.pylibmc')

--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -40,20 +40,12 @@ if not COMPRESS_LEVEL == -1:
     if not pylibmc.support_compression:
         warnings.warn('A compression level was provided but pylibmc was '
                       'not compiled with support for it.')
-    if not pylibmc.__version__ >= '1.3.0':
-        warnings.warn('A compression level was provided but pylibmc 1.3.0 '
-                      'or above is required to handle this option.')
-
 
 # Keyword arguments to configure compression options
-# based on capabilities of a provided pylibmc library.
 COMPRESS_KWARGS = {
-    # Requires pylibmc 1.0 and above. Given that the minumum supported
-    # version (as of now) is 1.1, the parameter is always included.
     'min_compress_len': MIN_COMPRESS_LEN,
+    'compress_level': COMPRESS_LEVEL,
 }
-if pylibmc.__version__ >= '1.3.0':
-    COMPRESS_KWARGS['compress_level'] = COMPRESS_LEVEL
 
 
 class PyLibMCCache(BaseMemcachedCache):


### PR DESCRIPTION
- Remove `DEFAULT_TIMEOUT` backwards compatibility support. (Since the lowest Django version supported is 1.8, and `DEFAULT_TIMEOUT`was added in Django 1.6: django/django@89955cc)
- Remove backwards compatibility support for pylibmc < 1.3.0. (Since the minimum pylibmc version required by setup.py is 1.4.1.)
