### PR TITLE
Use lazy logging when reporting memcached errors

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -112,18 +112,18 @@ class PyLibMCCache(BaseMemcachedCache):
                                    self.get_backend_timeout(timeout),
                                    **COMPRESS_KWARGS)
         except pylibmc.ServerError:
-            log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),
+            log.error('ServerError saving %s (%d bytes)', key, len(str(value)),
                       exc_info=True)
             return False
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return False
 
     def get(self, key, default=None, version=None):
         try:
             return super(PyLibMCCache, self).get(key, default, version)
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return default
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
@@ -133,37 +133,37 @@ class PyLibMCCache(BaseMemcachedCache):
                                    self.get_backend_timeout(timeout),
                                    **COMPRESS_KWARGS)
         except pylibmc.ServerError:
-            log.error('ServerError saving %s (%d bytes)' % (key, len(str(value))),
+            log.error('ServerError saving %s (%d bytes)', key, len(str(value)),
                       exc_info=True)
             return False
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return False
 
     def delete(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).delete(*args, **kwargs)
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return False
 
     def get_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).get_many(*args, **kwargs)
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return {}
 
     def set_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).set_many(*args, **kwargs)
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return False
 
     def delete_many(self, *args, **kwargs):
         try:
             return super(PyLibMCCache, self).delete_many(*args, **kwargs)
         except MemcachedError as e:
-            log.error('MemcachedError: %s' % e, exc_info=True)
+            log.error('MemcachedError: %s', e, exc_info=True)
             return False


### PR DESCRIPTION
Context being: [Sentry](https://sentry.io/) generates message fingerprints depending on how the message is constructed, because the string is interpolated before sending it to the logger it considers every message unique (because the message is always different). This way Sentry will collate them under the same entry.

Also this is how the Python docs document suggested logging (see: https://docs.python.org/2/library/logging.html#logging.Logger.debug)

```
logger.warning('Protocol problem: %s', 'connection reset', extra=d)
```
