### PR TITLE
Adjust text matrix for Django 2.0, Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # Config file for automatic testing at travis-ci.org
 
-# sudo: false appears to work, and makes for fast builds.
-#  memcached is started with "sudo service memcached start", which issues a
-#  warning about sudo, but also appears to start the service.
+# Use faster container-based builds
 sudo: false
 language: python
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,23 +23,23 @@ matrix:
         - env: TOXENV=py27-django110
           python: "2.7"
         - env: TOXENV=py34-django110
-          python: "3.5"
+          python: "3.4"
         - env: TOXENV=py35-django110
           python: "3.5"
         - env: TOXENV=py27-django111
           python: "2.7"
-        - env: TOXENV=py34-django111
-          python: "3.5"
         - env: TOXENV=py35-django111
           python: "3.5"
-        - env: TOXENV=py27-django-master
-          python: "2.7"
+        - env: TOXENV=py36-django111
+          python: "3.6"
         - env: TOXENV=py35-django-master
           python: "3.5"
+        - env: TOXENV=py36-django-master
+          python: "3.6"
     allow_failures:
         # Django master is allowed to fail
-        - env: TOXENV=py27-django-master
         - env: TOXENV=py35-django-master
+        - env: TOXENV=py36-django-master
 
 # See pylibmc's .travis.yml if a lot more configuration is needed
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: python
 install: pip install tox
 script: tox
 
+# Test two Python versions per supported Django version.
+# This balances testing all the Python and Django versions
+# while minimizing the work TravisCI does with each build.
 matrix:
     include:
         - env: TOXENV=py27-django18
@@ -14,20 +17,14 @@ matrix:
           python: "3.4"
         - env: TOXENV=py27-django19
           python: "2.7"
-        - env: TOXENV=py34-django19
-          python: "3.4"
         - env: TOXENV=py35-django19
           python: "3.5"
         - env: TOXENV=py27-django110
           python: "2.7"
-        - env: TOXENV=py34-django110
-          python: "3.4"
         - env: TOXENV=py35-django110
           python: "3.5"
         - env: TOXENV=py27-django111
           python: "2.7"
-        - env: TOXENV=py35-django111
-          python: "3.5"
         - env: TOXENV=py36-django111
           python: "3.6"
         - env: TOXENV=py35-django-master

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Requirements
 ------------
 
 django-pylibmc requires pylibmc 1.4.1 or above. It supports Django 1.8 through
-1.11, and Python versions 2.7, 3.4, and 3.5.
+1.11, and Python versions 2.7, 3.4, 3.5, and 3.6.
 
 Installation
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,16 @@
 
 [tox]
 envlist =
-    py{27,34,35}-django{18,19,110,111,-master},
+    py{27,34,35}-django{18,19,110}
+    py{27,34,35,36}-django111
+    py{35,36}-django-master
 
 [testenv]
 commands = {envpython} runtests.py
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django110: Django>=1.10a1,<1.11
-    django111: Django>=1.11a1,<2.0
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     django-master: https://github.com/django/django/archive/master.tar.gz
     pylibmc>=1.4.1


### PR DESCRIPTION
* Django 2.0 won't support Python 2.7, so remove from the matrix
* Django 1.11 and 2.0 support Python 3.6, so add to matrix