### PR TITLE
Increase test coverage & confirm support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           python: "2.7"
         - env: TOXENV=py36-django111
           python: "3.6"
+        - env: TOXENV=py35-django20
+          python: "3.5"
+        - env: TOXENV=py36-django20
+          python: "3.6"
         - env: TOXENV=py35-django-master
           python: "3.5"
         - env: TOXENV=py36-django-master

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Requirements
 ------------
 
 django-pylibmc requires pylibmc 1.4.1 or above. It supports Django 1.8 through
-1.11, and Python versions 2.7, 3.4, 3.5, and 3.6.
+2.0, and Python versions 2.7, 3.4, 3.5, and 3.6.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -56,6 +57,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import time
+
+from django.core import signals
 from django.core.cache import caches
-from django.test import TestCase
+from django.db import close_old_connections
+from django.test import TestCase, mock
+from django.utils import six
 
 from .models import Poll, expensive_calculation
+
+try:    # Use the same idiom as in cache backends
+    from django.utils.six.moves import cPickle as pickle
+except ImportError:
+    import pickle
+
 
 # functions/classes for complex data type tests
 def f():
@@ -16,15 +28,25 @@ class C:
         return 24
 
 
-# Lifted from tests/cache/tests.py in Django.
+class Unpicklable(object):
+    def __getstate__(self):
+        raise pickle.PickleError()
+
+
+# Lifted from:
+# https://github.com/django/django/blob/1.11.9/tests/cache/tests.py
 class PylibmcCacheTests(TestCase):
     cache_name = 'default'
+    # libmemcached manages its own connections.
+    should_disconnect_on_close = False
 
     def setUp(self):
         self.cache = caches[self.cache_name]
 
     def tearDown(self):
         self.cache.clear()
+
+    # #### From Django's BaseCacheTests ####
 
     def test_simple(self):
         # Simple cache set/get works
@@ -35,13 +57,13 @@ class PylibmcCacheTests(TestCase):
         # A key can be added to a cache
         self.cache.add("addkey1", "value")
         result = self.cache.add("addkey1", "newvalue")
-        self.assertEqual(result, False)
+        self.assertFalse(result)
         self.assertEqual(self.cache.get("addkey1"), "value")
 
     def test_non_existent(self):
         # Non-existent cache keys return as None/default
         # get with non-existent keys
-        self.assertEqual(self.cache.get("does_not_exist"), None)
+        self.assertIsNone(self.cache.get("does_not_exist"))
         self.assertEqual(self.cache.get("does_not_exist", "bang!"), "bang!")
 
     def test_get_many(self):
@@ -50,8 +72,8 @@ class PylibmcCacheTests(TestCase):
         self.cache.set('b', 'b')
         self.cache.set('c', 'c')
         self.cache.set('d', 'd')
-        self.assertEqual(self.cache.get_many(['a', 'c', 'd']), {'a' : 'a', 'c' : 'c', 'd' : 'd'})
-        self.assertEqual(self.cache.get_many(['a', 'b', 'e']), {'a' : 'a', 'b' : 'b'})
+        self.assertDictEqual(self.cache.get_many(['a', 'c', 'd']), {'a': 'a', 'c': 'c', 'd': 'd'})
+        self.assertDictEqual(self.cache.get_many(['a', 'b', 'e']), {'a': 'a', 'b': 'b'})
 
     def test_delete(self):
         # Cache keys can be deleted
@@ -59,20 +81,22 @@ class PylibmcCacheTests(TestCase):
         self.cache.set("key2", "eggs")
         self.assertEqual(self.cache.get("key1"), "spam")
         self.cache.delete("key1")
-        self.assertEqual(self.cache.get("key1"), None)
+        self.assertIsNone(self.cache.get("key1"))
         self.assertEqual(self.cache.get("key2"), "eggs")
 
     def test_has_key(self):
         # The cache can be inspected for cache keys
         self.cache.set("hello1", "goodbye1")
-        self.assertEqual(self.cache.has_key("hello1"), True)
-        self.assertEqual(self.cache.has_key("goodbye1"), False)
+        self.assertTrue(self.cache.has_key("hello1"))
+        self.assertFalse(self.cache.has_key("goodbye1"))
+        self.cache.set("no_expiry", "here", None)
+        self.assertTrue(self.cache.has_key("no_expiry"))
 
     def test_in(self):
         # The in operator can be used to inspet cache contents
         self.cache.set("hello2", "goodbye2")
-        self.assertEqual("hello2" in self.cache, True)
-        self.assertEqual("goodbye2" in self.cache, False)
+        self.assertIn("hello2", self.cache)
+        self.assertNotIn("goodbye2", self.cache)
 
     def test_incr(self):
         # Cache values can be incremented
@@ -81,7 +105,9 @@ class PylibmcCacheTests(TestCase):
         self.assertEqual(self.cache.get('answer'), 42)
         self.assertEqual(self.cache.incr('answer', 10), 52)
         self.assertEqual(self.cache.get('answer'), 52)
-        self.assertRaises(ValueError, self.cache.incr, 'does_not_exist')
+        self.assertEqual(self.cache.incr('answer', -10), 42)
+        with self.assertRaises(ValueError):
+            self.cache.incr('does_not_exist')
 
     def test_decr(self):
         # Cache values can be decremented
@@ -90,18 +116,20 @@ class PylibmcCacheTests(TestCase):
         self.assertEqual(self.cache.get('answer'), 42)
         self.assertEqual(self.cache.decr('answer', 10), 32)
         self.assertEqual(self.cache.get('answer'), 32)
-        self.assertRaises(ValueError, self.cache.decr, 'does_not_exist')
+        self.assertEqual(self.cache.decr('answer', -10), 42)
+        with self.assertRaises(ValueError):
+            self.cache.decr('does_not_exist')
 
     def test_data_types(self):
         # Many different data types can be cached
         stuff = {
-            'string'    : 'this is a string',
-            'int'       : 42,
-            'list'      : [1, 2, 3, 4],
-            'tuple'     : (1, 2, 3, 4),
-            'dict'      : {'A': 1, 'B' : 2},
-            'function'  : f,
-            'class'     : C,
+            'string': 'this is a string',
+            'int': 42,
+            'list': [1, 2, 3, 4],
+            'tuple': (1, 2, 3, 4),
+            'dict': {'A': 1, 'B': 2},
+            'function': f,
+            'class': C,
         }
         self.cache.set("stuff", stuff)
         self.assertEqual(self.cache.get("stuff"), stuff)
@@ -123,7 +151,7 @@ class PylibmcCacheTests(TestCase):
         # Don't want fields with callable as default to be called on cache write
         expensive_calculation.num_runs = 0
         Poll.objects.all().delete()
-        my_poll = Poll.objects.create(question="What?")
+        Poll.objects.create(question="What?")
         self.assertEqual(expensive_calculation.num_runs, 1)
         defer_qs = Poll.objects.all().defer('question')
         self.assertEqual(defer_qs.count(), 1)
@@ -136,14 +164,14 @@ class PylibmcCacheTests(TestCase):
         # Don't want fields with callable as default to be called on cache read
         expensive_calculation.num_runs = 0
         Poll.objects.all().delete()
-        my_poll = Poll.objects.create(question="What?")
+        Poll.objects.create(question="What?")
         self.assertEqual(expensive_calculation.num_runs, 1)
         defer_qs = Poll.objects.all().defer('question')
         self.assertEqual(defer_qs.count(), 1)
         self.cache.set('deferred_queryset', defer_qs)
         self.assertEqual(expensive_calculation.num_runs, 1)
         runs_before_cache_read = expensive_calculation.num_runs
-        cached_polls = self.cache.get('deferred_queryset')
+        self.cache.get('deferred_queryset')
         # We only want the default expensive calculation run on creation and set
         self.assertEqual(expensive_calculation.num_runs, runs_before_cache_read)
 
@@ -154,33 +182,61 @@ class PylibmcCacheTests(TestCase):
         self.cache.set('expire3', 'very quickly', 1)
 
         time.sleep(2)
-        self.assertEqual(self.cache.get("expire1"), None)
+        self.assertIsNone(self.cache.get("expire1"))
 
         self.cache.add("expire2", "newvalue")
         self.assertEqual(self.cache.get("expire2"), "newvalue")
-        self.assertEqual(self.cache.has_key("expire3"), False)
+        self.assertFalse(self.cache.has_key("expire3"))
 
     def test_unicode(self):
         # Unicode values can be cached
         stuff = {
-            u'ascii': u'ascii_value',
-            u'unicode_ascii': u'Iñtërnâtiônàlizætiøn1',
-            u'Iñtërnâtiônàlizætiøn': u'Iñtërnâtiônàlizætiøn2',
-            u'ascii': {u'x': 1}
-            }
+            'ascii': 'ascii_value',
+            'unicode_ascii': 'Iñtërnâtiônàlizætiøn1',
+            'Iñtërnâtiônàlizætiøn': 'Iñtërnâtiônàlizætiøn2',
+            'ascii2': {'x': 1}
+        }
+        # Test `set`
         for (key, value) in stuff.items():
             self.cache.set(key, value)
             self.assertEqual(self.cache.get(key), value)
 
+        # Test `add`
+        for (key, value) in stuff.items():
+            self.cache.delete(key)
+            self.cache.add(key, value)
+            self.assertEqual(self.cache.get(key), value)
+
+        # Test `set_many`
+        for (key, value) in stuff.items():
+            self.cache.delete(key)
+        self.cache.set_many(stuff)
+        for (key, value) in stuff.items():
+            self.assertEqual(self.cache.get(key), value)
+
     def test_binary_string(self):
-        # Binary strings should be cachable
+        # Binary strings should be cacheable
         from zlib import compress, decompress
-        value = b'value_to_be_compressed'
-        compressed_value = compress(value)
+        value = 'value_to_be_compressed'
+        compressed_value = compress(value.encode())
+
+        # Test set
         self.cache.set('binary1', compressed_value)
         compressed_result = self.cache.get('binary1')
         self.assertEqual(compressed_value, compressed_result)
-        self.assertEqual(value, decompress(compressed_result))
+        self.assertEqual(value, decompress(compressed_result).decode())
+
+        # Test add
+        self.cache.add('binary1-add', compressed_value)
+        compressed_result = self.cache.get('binary1-add')
+        self.assertEqual(compressed_value, compressed_result)
+        self.assertEqual(value, decompress(compressed_result).decode())
+
+        # Test set_many
+        self.cache.set_many({'binary1-set_many': compressed_value})
+        compressed_result = self.cache.get('binary1-set_many')
+        self.assertEqual(compressed_value, compressed_result)
+        self.assertEqual(value, decompress(compressed_result).decode())
 
     def test_set_many(self):
         # Multiple keys can be set using set_many
@@ -192,8 +248,8 @@ class PylibmcCacheTests(TestCase):
         # set_many takes a second ``timeout`` parameter
         self.cache.set_many({"key1": "spam", "key2": "eggs"}, 1)
         time.sleep(2)
-        self.assertEqual(self.cache.get("key1"), None)
-        self.assertEqual(self.cache.get("key2"), None)
+        self.assertIsNone(self.cache.get("key1"))
+        self.assertIsNone(self.cache.get("key2"))
 
     def test_delete_many(self):
         # Multiple keys can be deleted using delete_many
@@ -201,8 +257,8 @@ class PylibmcCacheTests(TestCase):
         self.cache.set("key2", "eggs")
         self.cache.set("key3", "ham")
         self.cache.delete_many(["key1", "key2"])
-        self.assertEqual(self.cache.get("key1"), None)
-        self.assertEqual(self.cache.get("key2"), None)
+        self.assertIsNone(self.cache.get("key1"))
+        self.assertIsNone(self.cache.get("key2"))
         self.assertEqual(self.cache.get("key3"), "ham")
 
     def test_clear(self):
@@ -210,39 +266,36 @@ class PylibmcCacheTests(TestCase):
         self.cache.set("key1", "spam")
         self.cache.set("key2", "eggs")
         self.cache.clear()
-        self.assertEqual(self.cache.get("key1"), None)
-        self.assertEqual(self.cache.get("key2"), None)
+        self.assertIsNone(self.cache.get("key1"))
+        self.assertIsNone(self.cache.get("key2"))
 
     def test_long_timeout(self):
-        '''
-        Using a timeout greater than 30 days makes memcached think
-        it is an absolute expiration timestamp instead of a relative
-        offset. Test that we honour this convention. Refs #12399.
-        '''
-        self.cache.set('key1', 'eggs', 60*60*24*30 + 1) #30 days + 1 second
+        """
+        Followe memcached's convention where a timeout greater than 30 days is
+        treated as an absolute expiration timestamp instead of a relative
+        offset (#12399).
+        """
+        self.cache.set('key1', 'eggs', 60 * 60 * 24 * 30 + 1)  # 30 days + 1 second
         self.assertEqual(self.cache.get('key1'), 'eggs')
 
-        self.cache.add('key2', 'ham', 60*60*24*30 + 1)
+        self.cache.add('key2', 'ham', 60 * 60 * 24 * 30 + 1)
         self.assertEqual(self.cache.get('key2'), 'ham')
 
-        self.cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, 60*60*24*30 + 1)
+        self.cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, 60 * 60 * 24 * 30 + 1)
         self.assertEqual(self.cache.get('key3'), 'sausage')
         self.assertEqual(self.cache.get('key4'), 'lobster bisque')
 
-    def test_none_timeout(self):
-        '''
-        Passing in None for the timeout results in the default timeout
-
-        In Django, it results in a value that is cached forever.  There's no
-        way to tell the difference in the context of a unit test.
-        '''
+    def test_forever_timeout(self):
+        """
+        Passing in None into timeout results in a value that is cached forever
+        """
         self.cache.set('key1', 'eggs', None)
         self.assertEqual(self.cache.get('key1'), 'eggs')
 
         self.cache.add('key2', 'ham', None)
         self.assertEqual(self.cache.get('key2'), 'ham')
         added = self.cache.add('key1', 'new eggs', None)
-        self.assertEqual(added, False)
+        self.assertIs(added, False)
         self.assertEqual(self.cache.get('key1'), 'eggs')
 
         self.cache.set_many({'key3': 'sausage', 'key4': 'lobster bisque'}, None)
@@ -250,12 +303,15 @@ class PylibmcCacheTests(TestCase):
         self.assertEqual(self.cache.get('key4'), 'lobster bisque')
 
     def test_zero_timeout(self):
-        '''
+        """
         Passing in zero for the timeout results in a value that is cached
         forever.
 
         In Django, it results in a value that is not cached.
-        '''
+        TODO: Re-sync this with the upstream test once django-pylibmc
+        follows the Django behaviour:
+        https://github.com/django-pylibmc/django-pylibmc/issues/35
+        """
         self.cache.set('key1', 'eggs', 0)
         self.assertEqual(self.cache.get('key1'), 'eggs')
 
@@ -273,6 +329,205 @@ class PylibmcCacheTests(TestCase):
         # Make sure a timeout given as a float doesn't crash anything.
         self.cache.set("key1", "spam", 100.2)
         self.assertEqual(self.cache.get("key1"), "spam")
+
+    def test_cache_versioning_get_set(self):
+        # set, using default version = 1
+        self.cache.set('answer1', 42)
+        self.assertEqual(self.cache.get('answer1'), 42)
+        self.assertEqual(self.cache.get('answer1', version=1), 42)
+        self.assertIsNone(self.cache.get('answer1', version=2))
+
+        # set, default version = 1, but manually override version = 2
+        self.cache.set('answer2', 42, version=2)
+        self.assertIsNone(self.cache.get('answer2'))
+        self.assertIsNone(self.cache.get('answer2', version=1))
+        self.assertEqual(self.cache.get('answer2', version=2), 42)
+
+    def test_cache_versioning_add(self):
+        # add, default version = 1, but manually override version = 2
+        self.cache.add('answer1', 42, version=2)
+        self.assertIsNone(self.cache.get('answer1', version=1))
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+
+        self.cache.add('answer1', 37, version=2)
+        self.assertIsNone(self.cache.get('answer1', version=1))
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+
+        self.cache.add('answer1', 37, version=1)
+        self.assertEqual(self.cache.get('answer1', version=1), 37)
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+
+    def test_cache_versioning_has_key(self):
+        self.cache.set('answer1', 42)
+
+        # has_key
+        self.assertTrue(self.cache.has_key('answer1'))
+        self.assertTrue(self.cache.has_key('answer1', version=1))
+        self.assertFalse(self.cache.has_key('answer1', version=2))
+
+    def test_cache_versioning_delete(self):
+        self.cache.set('answer1', 37, version=1)
+        self.cache.set('answer1', 42, version=2)
+        self.cache.delete('answer1')
+        self.assertIsNone(self.cache.get('answer1', version=1))
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+
+        self.cache.set('answer2', 37, version=1)
+        self.cache.set('answer2', 42, version=2)
+        self.cache.delete('answer2', version=2)
+        self.assertEqual(self.cache.get('answer2', version=1), 37)
+        self.assertIsNone(self.cache.get('answer2', version=2))
+
+    def test_cache_versioning_incr_decr(self):
+        self.cache.set('answer1', 37, version=1)
+        self.cache.set('answer1', 42, version=2)
+        self.cache.incr('answer1')
+        self.assertEqual(self.cache.get('answer1', version=1), 38)
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+        self.cache.decr('answer1')
+        self.assertEqual(self.cache.get('answer1', version=1), 37)
+        self.assertEqual(self.cache.get('answer1', version=2), 42)
+
+        self.cache.set('answer2', 37, version=1)
+        self.cache.set('answer2', 42, version=2)
+        self.cache.incr('answer2', version=2)
+        self.assertEqual(self.cache.get('answer2', version=1), 37)
+        self.assertEqual(self.cache.get('answer2', version=2), 43)
+        self.cache.decr('answer2', version=2)
+        self.assertEqual(self.cache.get('answer2', version=1), 37)
+        self.assertEqual(self.cache.get('answer2', version=2), 42)
+
+    def test_cache_versioning_get_set_many(self):
+        # set, using default version = 1
+        self.cache.set_many({'ford1': 37, 'arthur1': 42})
+        self.assertDictEqual(self.cache.get_many(['ford1', 'arthur1']), {'ford1': 37, 'arthur1': 42})
+        self.assertDictEqual(self.cache.get_many(['ford1', 'arthur1'], version=1), {'ford1': 37, 'arthur1': 42})
+        self.assertDictEqual(self.cache.get_many(['ford1', 'arthur1'], version=2), {})
+
+        # set, default version = 1, but manually override version = 2
+        self.cache.set_many({'ford2': 37, 'arthur2': 42}, version=2)
+        self.assertDictEqual(self.cache.get_many(['ford2', 'arthur2']), {})
+        self.assertDictEqual(self.cache.get_many(['ford2', 'arthur2'], version=1), {})
+        self.assertDictEqual(self.cache.get_many(['ford2', 'arthur2'], version=2), {'ford2': 37, 'arthur2': 42})
+
+    def test_incr_version(self):
+        self.cache.set('answer', 42, version=2)
+        self.assertIsNone(self.cache.get('answer'))
+        self.assertIsNone(self.cache.get('answer', version=1))
+        self.assertEqual(self.cache.get('answer', version=2), 42)
+        self.assertIsNone(self.cache.get('answer', version=3))
+
+        self.assertEqual(self.cache.incr_version('answer', version=2), 3)
+        self.assertIsNone(self.cache.get('answer'))
+        self.assertIsNone(self.cache.get('answer', version=1))
+        self.assertIsNone(self.cache.get('answer', version=2))
+        self.assertEqual(self.cache.get('answer', version=3), 42)
+
+        with self.assertRaises(ValueError):
+            self.cache.incr_version('does_not_exist')
+
+    def test_decr_version(self):
+        self.cache.set('answer', 42, version=2)
+        self.assertIsNone(self.cache.get('answer'))
+        self.assertIsNone(self.cache.get('answer', version=1))
+        self.assertEqual(self.cache.get('answer', version=2), 42)
+
+        self.assertEqual(self.cache.decr_version('answer', version=2), 1)
+        self.assertEqual(self.cache.get('answer'), 42)
+        self.assertEqual(self.cache.get('answer', version=1), 42)
+        self.assertIsNone(self.cache.get('answer', version=2))
+
+        with self.assertRaises(ValueError):
+            self.cache.decr_version('does_not_exist', version=2)
+
+    def test_add_fail_on_pickleerror(self):
+        # Shouldn't fail silently if trying to cache an unpicklable type.
+        with self.assertRaises(pickle.PickleError):
+            self.cache.add('unpicklable', Unpicklable())
+
+    def test_set_fail_on_pickleerror(self):
+        with self.assertRaises(pickle.PickleError):
+            self.cache.set('unpicklable', Unpicklable())
+
+    def test_get_or_set(self):
+        self.assertIsNone(self.cache.get('projector'))
+        self.assertEqual(self.cache.get_or_set('projector', 42), 42)
+        self.assertEqual(self.cache.get('projector'), 42)
+        self.assertEqual(self.cache.get_or_set('null', None), None)
+
+    def test_get_or_set_callable(self):
+        def my_callable():
+            return 'value'
+
+        self.assertEqual(self.cache.get_or_set('mykey', my_callable), 'value')
+        self.assertEqual(self.cache.get_or_set('mykey', my_callable()), 'value')
+
+    def test_get_or_set_callable_returning_none(self):
+        self.assertIsNone(self.cache.get_or_set('mykey', lambda: None))
+        # Previous get_or_set() doesn't store None in the cache.
+        self.assertEqual(self.cache.get('mykey', 'default'), 'default')
+
+    def test_get_or_set_version(self):
+        msg = (
+            "get_or_set() missing 1 required positional argument: 'default'"
+            if six.PY3
+            else 'get_or_set() takes at least 3 arguments'
+        )
+        self.cache.get_or_set('brian', 1979, version=2)
+        with self.assertRaisesMessage(TypeError, msg):
+            self.cache.get_or_set('brian')
+        with self.assertRaisesMessage(TypeError, msg):
+            self.cache.get_or_set('brian', version=1)
+        self.assertIsNone(self.cache.get('brian', version=1))
+        self.assertEqual(self.cache.get_or_set('brian', 42, version=1), 42)
+        self.assertEqual(self.cache.get_or_set('brian', 1979, version=2), 1979)
+        self.assertIsNone(self.cache.get('brian', version=3))
+
+    # #### From Django's BaseMemcachedTests ####
+
+    def test_invalid_key_length(self):
+        # memcached limits key length to 250
+        with self.assertRaises(Exception):
+            self.cache.set('a' * 251, 'value')
+
+    def test_memcached_deletes_key_on_failed_set(self):
+        # By default memcached allows objects up to 1MB. For the cache_db session
+        # backend to always use the current session, memcached needs to delete
+        # the old key if it fails to set.
+        # pylibmc doesn't seem to have SERVER_MAX_VALUE_LENGTH as far as I can
+        # tell from a quick check of its source code. This is falling back to
+        # the default value exposed by python-memcached on my system.
+        max_value_length = getattr(self.cache._lib, 'SERVER_MAX_VALUE_LENGTH', 1048576)
+
+        self.cache.set('small_value', 'a')
+        self.assertEqual(self.cache.get('small_value'), 'a')
+
+        large_value = 'a' * (max_value_length + 1)
+        try:
+            self.cache.set('small_value', large_value)
+        except Exception:
+            # Some clients (e.g. pylibmc) raise when the value is too large,
+            # while others (e.g. python-memcached) intentionally return True
+            # indicating success. This test is primarily checking that the key
+            # was deleted, so the return/exception behavior for the set()
+            # itself is not important.
+            pass
+        # small_value should be deleted, or set if configured to accept larger values
+        value = self.cache.get('small_value')
+        self.assertTrue(value is None or value == large_value)
+
+    def test_close(self):
+        # For clients that don't manage their connections properly, the
+        # connection is closed when the request is complete.
+        signals.request_finished.disconnect(close_old_connections)
+        try:
+            with mock.patch.object(self.cache._lib.Client, 'disconnect_all', autospec=True) as mock_disconnect:
+                signals.request_finished.send(self.__class__)
+                self.assertIs(mock_disconnect.called, self.should_disconnect_on_close)
+        finally:
+            signals.request_finished.connect(close_old_connections)
+
+    # #### django-pylibmc specific ####
 
     def test_gt_1MB_value(self):
         # Test value > 1M gets compressed and stored

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,10 +9,16 @@ import django
 from django.core import signals
 from django.core.cache import caches
 from django.db import close_old_connections
-from django.test import TestCase, mock
+from django.test import TestCase
 from django.utils import six
 
 from .models import Poll, expensive_calculation
+
+try:
+    from unittest import mock
+except ImportError:
+    # Python 2
+    import mock
 
 try:    # Use the same idiom as in cache backends
     from django.utils.six.moves import cPickle as pickle

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist =
     py{27,34,35}-django{18,19,110}
     py{27,34,35,36}-django111
+    py{35,36}-django20
     py{35,36}-django-master
 
 [testenv]
@@ -16,6 +17,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
     django-master: https://github.com/django/django/archive/master.tar.gz
     pylibmc>=1.4.1
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,4 @@ deps =
     django111: Django>=1.11,<2.0
     django-master: https://github.com/django/django/archive/master.tar.gz
     pylibmc>=1.4.1
+    mock


### PR DESCRIPTION
This:
* Re-syncs the tests with Django 1.11's cache tests (which are the latest version to support Python 2)
* Adds explicit testing against Django 2.0 rather than just django-master

See individual commit messages for more details.

In later PRs I will:
* update the changelog for the various other PRs that have landed since the last release
* add some additional tests around the custom options handling in django-pylibmc
* fix a couple of quick win and non-breaking issues (like #6), then ideally a point release can be created
* eventually drop support for older Django and work on #36 (which will require a major version bump since it's a breaking change) and other simplification now that many of the features offered by django-pylibmc are resolved in Django's stock pylibmc backend