### PR TITLE
Stop closing pylibmc connections after each request

### DIFF
--- a/django_pylibmc/memcached.py
+++ b/django_pylibmc/memcached.py
@@ -154,3 +154,10 @@ class PyLibMCCache(BaseMemcachedCache):
         except MemcachedError as e:
             log.error('MemcachedError: %s', e, exc_info=True)
             return False
+
+    def close(self, **kwargs):
+        # Override BaseMemcachedCache since libmemcached manages its own connections,
+        # and calling disconnect_all() resets the failover state and causes unnecessary
+        # reconnects. Copied from Django's PyLibMCCache backend:
+        # https://github.com/django/django/blob/1.11.9/django/core/cache/backends/memcached.py#L207-L210
+        pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -530,8 +530,6 @@ class PylibmcCacheTests(TestCase):
         value = self.cache.get('small_value')
         self.assertTrue(value is None or value == large_value)
 
-    # TODO: Fix https://github.com/django-pylibmc/django-pylibmc/issues/6
-    @unittest.expectedFailure
     def test_close(self):
         # For clients that don't manage their connections properly, the
         # connection is closed when the request is complete.


### PR DESCRIPTION
Since this resets the failover state, and creates an unnecessary amount of reconnects. This is the same fix that was applied to Django's own pylibmc backend in django/django#7200.

(django-pylibmc inherits from `BaseMemcachedCache` so doesn't benefit from the upstream fix automatically - in the future that should probably change, however it will be a more risky PR, due to it also affecting the behaviour of `_cache()`)

This fix reduced our average query time in production by 70%.

![pylibmc persistent connection - new relic](https://user-images.githubusercontent.com/501702/35486689-ac5bcecc-0469-11e8-9f38-5a387d0b4ebb.png)

And here's a graph of "number of new connections per unit of time", where the drop is when this fix was deployed to production (before then being reverted, pending this fix upstream):

![django-pylibmc persistent connection - memcachier](https://user-images.githubusercontent.com/501702/35486722-1b275a92-046a-11e8-8fec-5366fe163c6e.png)

Fixes #6.

Note: This PR will conflict with #53 - I'll rebase whichever doesn't land first.