### PR TITLE
Django 3.* support, tests for Django >=2.1,<3.2 and python 3.7, 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
           python: "3.6"
         - env: TOXENV=py35-django20
           python: "3.5"
-        - env: TOXENV=py36-django20
+        - env: TOXENV=py38-django20
           python: "3.8"
         - env: TOXENV=py35-django21
           python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,31 @@ matrix:
         - env: TOXENV=py35-django20
           python: "3.5"
         - env: TOXENV=py36-django20
-          python: "3.6"
-        - env: TOXENV=py35-django-master
+          python: "3.8"
+        - env: TOXENV=py35-django21
           python: "3.5"
-        - env: TOXENV=py36-django-master
+        - env: TOXENV=py38-django21
+          python: "3.8"
+        - env: TOXENV=py35-django22
+          python: "3.5"
+        - env: TOXENV=py38-django22
+          python: "3.8"
+        - env: TOXENV=py36-django30
           python: "3.6"
+        - env: TOXENV=py38-django30
+          python: "3.8"
+        - env: TOXENV=py36-django31
+          python: "3.6"
+        - env: TOXENV=py38-django31
+          python: "3.8"
+        - env: TOXENV=py37-django-master
+          python: "3.7"
+        - env: TOXENV=py38-django-master
+          python: "3.8"
     allow_failures:
         # Django master is allowed to fail
-        - env: TOXENV=py35-django-master
-        - env: TOXENV=py36-django-master
+        - env: TOXENV=py37-django-master
+        - env: TOXENV=py38-django-master
 
 # See pylibmc's .travis.yml if a lot more configuration is needed
 services:

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Requirements
 ------------
 
 django-pylibmc requires pylibmc 1.4.1 or above. It supports Django 1.8 through
-2.0, and Python versions 2.7, 3.4, 3.5, and 3.6.
+3.1, and Python versions 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8
 
 Installation
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 
 # Django
-Django>=1.8,<2.1
+Django>=1.8,<3.2
 
 # This project
 -e .

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,10 @@ setup(
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -90,6 +94,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import sys
 import time
 from unittest import skipIf
 
@@ -10,7 +11,6 @@ from django.core import signals
 from django.core.cache import caches
 from django.db import close_old_connections
 from django.test import TestCase
-from django.utils import six
 
 from .models import Poll, expensive_calculation
 
@@ -24,6 +24,9 @@ try:    # Use the same idiom as in cache backends
     from django.utils.six.moves import cPickle as pickle
 except ImportError:
     import pickle
+
+
+PY3 = sys.version_info[0] == 3
 
 
 # functions/classes for complex data type tests
@@ -484,7 +487,7 @@ class PylibmcCacheTests(TestCase):
     def test_get_or_set_version(self):
         msg = (
             "get_or_set() missing 1 required positional argument: 'default'"
-            if six.PY3
+            if PY3
             else 'get_or_set() takes at least 3 arguments'
         )
         self.cache.get_or_set('brian', 1979, version=2)

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,12 @@ envlist =
     lint
     py{27,34,35}-django{18,19,110}
     py{27,34,35,36}-django111
-    py{35,36}-django20
-    py{35,36}-django-master
+    py{35,36,37,38}-django20
+    py{35,36,37,38}-django21
+    py{35,36,37,38}-django22
+    py{36,37,38}-django30
+    py{36,37,38}-django31
+    py{36,37,38}-django-master
 
 [testenv]
 commands = {envpython} runtests.py
@@ -19,6 +23,10 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2<3.0
+    django30: Django>=3.0<3.1
+    django31: Django>=3.1<3.2
     django-master: https://github.com/django/django/archive/master.tar.gz
     pylibmc>=1.4.1
     mock


### PR DESCRIPTION
Since there is still no handling for pylibmc connection/server exceptions in Django's PyLibMCCache backend, would be nice to update django-pylibmc to be able to continue using it with newer Django versions.